### PR TITLE
listdiff renamed to setdiff1d to reflect API change

### DIFF
--- a/1/indexed_operations.py
+++ b/1/indexed_operations.py
@@ -11,6 +11,6 @@ boolx = tf.constant([[True,False], [False,True]])
 
 tf.argmin(x, 1).eval() # Position of the maximum value of columns
 tf.argmax(x, 1).eval() # Position of the minimum value of rows
-tf.listdiff(listx, listy)[0].eval() # List differences
+tf.setdiff1d(listx, listy)[0].eval() # List differences
 tf.where(boolx).eval() # Show true values
 tf.unique(listx)[0].eval() # Unique values in list


### PR DESCRIPTION
tf.listdiff has been renamed to tf.setdiff1d to match NumPy naming in tensorflow